### PR TITLE
Fix max time issues that come with ...

### DIFF
--- a/ManagedAssembly/MultipleBombsAssembly/MultipleBombsAssembly/MultipleBombs.cs
+++ b/ManagedAssembly/MultipleBombsAssembly/MultipleBombsAssembly/MultipleBombs.cs
@@ -161,15 +161,15 @@ namespace MultipleBombsAssembly
                     device.Screen.CurrentState = FreeplayScreen.State.Start;
                     device.Screen.ScreenText.text = "BOMBS:\n\nNumber of bombs\nto defuse\n\n<size=20><#00ff00>Multiple Bombs Mod</color></size>";
                 });
-                if (FreeplayDevice.MAX_SECONDS_TO_SOLVE == 600f)
+
+                //Dealing with the case where the user uses at_bash's mod selector to enable/disable bomb casings after the fact.
+                float newMaxTime = 600.0f * maxBombCount;
+                if (ModManager.Instance.GetMaximumModules() > FreeplayDevice.MAX_MODULE_COUNT)
                 {
-                    float newMaxTime = FreeplayDevice.MAX_SECONDS_TO_SOLVE * maxBombCount;
-                    if (ModManager.Instance.GetMaximumModules() > FreeplayDevice.MAX_MODULE_COUNT)
-                    {
-                        newMaxTime += (ModManager.Instance.GetMaximumModules() - FreeplayDevice.MAX_MODULE_COUNT) * 60 * (maxBombCount - 1);
-                    }
-                    FreeplayDevice.MAX_SECONDS_TO_SOLVE = newMaxTime;
+                    newMaxTime += (ModManager.Instance.GetMaximumModules() - FreeplayDevice.MAX_MODULE_COUNT) * 60 *
+                                  (maxBombCount - 1);
                 }
+                FreeplayDevice.MAX_SECONDS_TO_SOLVE = newMaxTime;
 
                 modulesObject.transform.FindChild("Modules_INCR_btn").GetComponent<Selectable>().OnHighlight = new Action(() =>
                 {


### PR DESCRIPTION
enabling or disableing bomb casings with at_bash's mod selector.

(The bug is that if Quad decker was disabled, then you enabled it,
instead of max time going from 20:00 to 92:00, max time goes from 20:00
to 56:00.   Ditto in reverse,  if Quad decker was enabled on start then
disabled later,  Max time would go from 92:00 to 56:00 instead of 92:00
to 20:00.)

Ditto with Double decker,  (time from 20:00 to 32:00 instead of 20:00 to
44:00),  or from double to Quad decker,  (44:00 to 68:00 instead of
44:00 to 92:00).